### PR TITLE
Fix #9: add plugin for deployment on stamp-maven-repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <github.global.server>github</github.global.server>
     </properties>
 
     <dependencies>
@@ -38,6 +39,14 @@
         </dependency>
 
     </dependencies>
+
+    <distributionManagement>
+        <repository>
+            <id>internal.repo</id>
+            <name>Temporary Staging Repository</name>
+            <url>file://${project.build.directory}/mvn-repo</url>
+        </repository>
+    </distributionManagement>
 
     <build>
         <plugins>
@@ -91,6 +100,48 @@
                 <groupId>org.eluder.coveralls</groupId>
                 <artifactId>coveralls-maven-plugin</artifactId>
                 <version>4.3.0</version>
+            </plugin>
+
+
+            <!-- to deploy pitest-descartes on github -->
+            <plugin>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>2.8.1</version>
+                <configuration>
+                    <altDeploymentRepository>internal.repo::default::file://${project.build.directory}/master
+                    </altDeploymentRepository>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>com.github.github</groupId>
+                <artifactId>site-maven-plugin</artifactId>
+                <version>0.11</version>
+                <configuration>
+                    <path>${project.distributionManagement.site.url}</path>
+                    <merge>true</merge>
+                    <message>Maven artifacts for ${project.version}</message>  <!-- git commit message -->
+                    <outputDirectory>${project.build.directory}/master
+                    </outputDirectory> <!-- matches distribution management repository url above -->
+                    <branch>refs/heads/master</branch>                       <!-- remote branch name -->
+                    <includes>
+                        <include>**/*</include>
+                    </includes>
+                    <excludes>
+                        <exclude>**/*jar-with-dependencies.jar</exclude>
+                    </excludes>
+                    <repositoryName>stamp-maven-repository</repositoryName>      <!-- github repo name -->
+                    <repositoryOwner>STAMP-project</repositoryOwner>    <!-- github username  -->
+                </configuration>
+                <executions>
+                    <!-- run site-maven-plugin's 'site' target as part of the build's normal 'deploy' phase -->
+                    <execution>
+                        <goals>
+                            <goal>site</goal>
+                        </goals>
+                        <phase>deploy</phase>
+                    </execution>
+                </executions>
             </plugin>
 
         </plugins>


### PR DESCRIPTION
Hello,

I added the plugin required to deploy automatically pitest-descartes on the  [stamp-maven-repository](https://github.com/STAMP-project/stamp-maven-repository).

The procedure is simple (but quite dangerous).
Add to your `settings.xml` of your maven local repository the following lines:

```xml
<server>
    <id>github</id>
    <username>USERNAME</username>
    <password>PASSWORD<password>
</server>
```

And replace USERNAME and PASSWORD by your credentials. Ensure that the settings.xml is not visible by the world (chmod 700 settings.xml). Delete the value of PASSWORD when you finish the deployment. 

Then, in the folder of pitest-descartes, type the following maven  command line:
```
mvn clean deploy
```

See the repository, I did a first deployment of pitest-descartes.

Cheers, Benjamin.