### PR TITLE
Stop method for null return

### DIFF
--- a/src/main/java/eu/stamp_project/mutationtest/descartes/stopmethods/StopMethodMatcherInterceptorFactory.java
+++ b/src/main/java/eu/stamp_project/mutationtest/descartes/stopmethods/StopMethodMatcherInterceptorFactory.java
@@ -35,6 +35,7 @@ public class StopMethodMatcherInterceptorFactory implements MutationInterceptorF
         availabeMatchers.put("delegate", isDelegate());
         availabeMatchers.put("clinit", isStaticInitializer());
         availabeMatchers.put("empty_array", returnsAnEmptyArray());
+        availabeMatchers.put("null_return", returnsNull());
 
         String description = "Allows to reinsert some stop methods to the analysis. Possible values are: ";
         description += availabeMatchers.keySet().stream().collect(Collectors.joining(", "));

--- a/src/main/java/eu/stamp_project/mutationtest/descartes/stopmethods/StopMethodMatchers.java
+++ b/src/main/java/eu/stamp_project/mutationtest/descartes/stopmethods/StopMethodMatchers.java
@@ -111,6 +111,12 @@ public interface StopMethodMatchers {
                         .then(opCode(ARETURN))
         );
     }
+    
+    static StopMethodMatcher returnsNull() {
+        return forBody(
+          match(opCode(ACONST_NULL))
+          .then(opCode(ARETURN)));
+    }
 
 
 


### PR DESCRIPTION
I would like to propose a further stop method for `return null`, although it is already included in another one (constant return).
While the motivation for stop methods with constant return is motivated by excluding less relevant pseudo-tested methods (and hence, depends on the purpose of the analysis), the stop for return null helps to reduce equivalent mutants (if constant return is disabled). Hence, I can see use cases where I may not want to use the constant return stop methods, but the return null stop methods.

(I think the computational overhead of this partially redundant filtering is absolutely negligible because the vast majority of the effort goes into executing the tests.)