### PR TITLE
fix(asm): ASM5 should be replaced by ASM7 everywhere

### DIFF
--- a/src/main/java/eu/stamp_project/mutationtest/descartes/bodyanalysis/MethodInspector.java
+++ b/src/main/java/eu/stamp_project/mutationtest/descartes/bodyanalysis/MethodInspector.java
@@ -15,7 +15,7 @@ public class MethodInspector extends MethodVisitor {
     private LineCounter lineCounter;
 
     public MethodInspector(ClassName className, Method method, MutationPointFinder finder) {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
 
         this.method = method;
         this.finder = finder;

--- a/src/main/java/eu/stamp_project/mutationtest/descartes/codegeneration/MethodRewriterAdapter.java
+++ b/src/main/java/eu/stamp_project/mutationtest/descartes/codegeneration/MethodRewriterAdapter.java
@@ -8,9 +8,9 @@ import org.pitest.reloc.asm.*;
  */
 public abstract class MethodRewriterAdapter extends MethodVisitor {
 
-    public MethodRewriterAdapter() { super(Opcodes.ASM5); }
+    public MethodRewriterAdapter() { super(Opcodes.ASM7); }
 
-    public MethodRewriterAdapter(MethodVisitor mv) { super(Opcodes.ASM5, mv); }
+    public MethodRewriterAdapter(MethodVisitor mv) { super(Opcodes.ASM7, mv); }
 
     @Override
     public abstract void visitCode();

--- a/src/main/java/eu/stamp_project/mutationtest/descartes/codegeneration/MutationClassAdapter.java
+++ b/src/main/java/eu/stamp_project/mutationtest/descartes/codegeneration/MutationClassAdapter.java
@@ -13,7 +13,7 @@ public class MutationClassAdapter extends ClassVisitor {
     private final MutationIdentifier mID;
 
     public MutationClassAdapter(MutationIdentifier mID, ClassVisitor cv) {
-        super(Opcodes.ASM5, cv);
+        super(Opcodes.ASM7, cv);
         this.mID = mID;
     }
 


### PR DESCRIPTION
Descartes cannot analyse some specific Java code such as anonymous classes compiled with Java 11 (different byte code I guess). Using ASM7 fixes the problem.

To reproduce the issue:
- clone https://github.com/interacto/interacto-java-api
- launch descartes (already configured)
=> errors from pitest rise: "this feature requires ASM7" or something like that.

With this PR, these errors vanished.

Related to #108 
