### PR TITLE
Adding Experimental Support for Fluent API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,30 @@
-../.DS_Store/
-.DS_Store
-operators/.DS_Store
+*.class
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.ear
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+
+# IDE files
+.idea/
+*.iml
+
+# Build files
+target/
+
+# Generated files
+gen/
+
+# VSCode
+.vscode/
+
+# Eclipse
+.settings/
+.classpath
+.project

--- a/.gitignore
+++ b/.gitignore
@@ -1,30 +1,3 @@
-*.class
-
-# Mobile Tools for Java (J2ME)
-.mtj.tmp/
-
-# Package Files #
-*.jar
-*.war
-*.ear
-
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
-hs_err_pid*
-
-# IDE files
-.idea/
-*.iml
-
-# Build files
-target/
-
-# Generated files
-gen/
-
-# VSCode
-.vscode/
-
-# Eclipse
-.settings/
-.classpath
-.project
+../.DS_Store/
+.DS_Store
+operators/.DS_Store

--- a/src/main/java/eu/stamp_project/mutationtest/descartes/operators/MutationOperator.java
+++ b/src/main/java/eu/stamp_project/mutationtest/descartes/operators/MutationOperator.java
@@ -25,13 +25,16 @@ public abstract class MutationOperator {
 
     public abstract String getDescription();
 
+    public abstract boolean canReturnSelfObject(Method method);
+
     public static MutationOperator fromID(String id) {
         OperatorParser parser = new OperatorParser(id);
         Object value = parser.parse();
         if(parser.hasErrors())
             throw new WrongOperatorException("Invalid operator id: " + parser.getErrors().get(0));
-        if(value == null)
+        if(value == null) {
             return new NullMutationOperator();
+        }
         if (value.equals(Token.NEW.getData())) {
         	return new NewInstanceMutationOperator();
         }

--- a/src/main/java/eu/stamp_project/mutationtest/descartes/operators/NullMutationOperator.java
+++ b/src/main/java/eu/stamp_project/mutationtest/descartes/operators/NullMutationOperator.java
@@ -1,5 +1,7 @@
 package eu.stamp_project.mutationtest.descartes.operators;
 
+import java.lang.annotation.Retention;
+
 import org.pitest.reloc.asm.MethodVisitor;
 import org.pitest.reloc.asm.Opcodes;
 import org.pitest.reloc.asm.Type;
@@ -20,13 +22,25 @@ public class NullMutationOperator extends MutationOperator{
     @Override
     public boolean canMutate(Method method) {
         int target = method.getReturnType().getSort();
-        return  target == Type.OBJECT || target == Type.ARRAY;
+        return target == Type.OBJECT || target == Type.ARRAY;
     }
 
     @Override
+    public boolean canReturnSelfObject(Method method) {
+        int target = method.getReturnType().getSort();
+        if (target == Type.OBJECT)
+            return true;
+        if (target == Type.ARRAY)
+            return false;
+        return false;
+    }
+    @Override
     public void generateCode(Method method, MethodVisitor mv) {
         assert canMutate(method);
-        mv.visitInsn(Opcodes.ACONST_NULL);
+        if(canReturnSelfObject(method))
+            mv.visitVarInsn(Opcodes.ALOAD, 0);
+        else
+            mv.visitInsn(Opcodes.ACONST_NULL);
         mv.visitInsn(Opcodes.ARETURN);
     }
 


### PR DESCRIPTION
In Order to generate interesting mutations, ` return null ` has been removed whenever the returned object was a referenced one. 
Instead now the function body is replaced by ` return this `
For all other cases it stays the same.
For Issue - #97 