### PR TITLE
Fixing link to PITest Method Interceptor section

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ issues, see <http://pitest.org/quickstart/maven/>.
 
 ##### Configuring stop methods
 
-To configure the stop methods under consideration Descartes provide a `STOP_METHODS` [feature](http://pitest.org/quickstart/advanced/#mutation-interceptor").
+To configure the stop methods under consideration Descartes provide a `STOP_METHODS` [feature](http://pitest.org/quickstart/advanced/#mutation-interceptor).
 This feature is enabled by default. The parameter `exclude` can be used to prevent certain methods to be treated as stop methods and bring them back to the analysis. This parameter can take any of the following values:
 
 


### PR DESCRIPTION
The [previous link](http://pitest.org/quickstart/advanced/#mutation-interceptor") was sending the reader to the top of [PITest Advanced Usage page](http://pitest.org/quickstart/advanced/).

The [new link](http://pitest.org/quickstart/advanced/#mutation-interceptor) goes to the correct page section.