### PR TITLE
Update Pitest and Descartes versions in the examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ For quick configuration snippets showing how to use other testing frameworks suc
 
 If you use a multi-module project take a look at [PitMP](https://github.com/STAMP-project/pitmp-maven-plugin).
 
+You can also see how Pitest and Descartes are used in the following example projects:
+- [An example of effective mutation testing in Spring Boot 3 projects with Maven](https://github.com/ismail2ov/mutation-testing-with-maven)
+- [An example of effective mutation testing in Spring Boot 3 projects with Gradle](https://github.com/ismail2ov/mutation-testing-with-gradle)
+
 ## Table of contents
   - [How does Descartes work?](#how-does-descartes-work)
   - [Descartes Output](#descartes-output)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To use Descartes in a Maven project, add the following plugin configuration to y
 <plugin>
   <groupId>org.pitest</groupId>
   <artifactId>pitest-maven</artifactId>
-  <version>1.7.0</version>
+  <version>1.20.2</version>
   <configuration>
     <mutationEngine>descartes</mutationEngine>
   </configuration>
@@ -24,7 +24,7 @@ To use Descartes in a Maven project, add the following plugin configuration to y
     <dependency>
       <groupId>eu.stamp-project</groupId>
       <artifactId>descartes</artifactId>
-      <version>1.3.2</version>
+      <version>1.3.3</version>
     </dependency>
   </dependencies>
 </plugin>
@@ -421,7 +421,7 @@ The minimum configuration to use Descartes in a Maven project is the following:
 <plugin>
   <groupId>org.pitest</groupId>
   <artifactId>pitest-maven</artifactId>
-  <version>1.7.0</version>
+  <version>1.20.2</version>
   <configuration>
     <mutationEngine>descartes</mutationEngine>
   </configuration>
@@ -429,7 +429,7 @@ The minimum configuration to use Descartes in a Maven project is the following:
     <dependency>
       <groupId>eu.stamp-project</groupId>
       <artifactId>descartes</artifactId>
-      <version>1.3.2</version>
+      <version>1.3.3</version>
     </dependency>
   </dependencies>
 </plugin>
@@ -442,7 +442,7 @@ Later, one need to run the mutation coverage goal provided by the PIT Maven plug
 ```
 cd my-project-under-test
 mvn clean package # ensures clean state
-mvn org.pitest:pitest-maven:mutationCoverage
+mvn pitest:mutationCoverage
 ```
 ##### Specifying operators
 
@@ -561,7 +561,7 @@ They can be configured and combined as regular PIT report formats:
 <plugin>
   <groupId>org.pitest</groupId>
   <artifactId>pitest-maven</artifactId>
-  <version>1.7.0</version>
+  <version>1.20.2</version>
   <configuration>
     <outputFormats>
       <value>JSON</value>
@@ -574,7 +574,7 @@ They can be configured and combined as regular PIT report formats:
     <dependency>
       <groupId>eu.stamp-project</groupId>
       <artifactId>descartes</artifactId>
-      <version>1.3.2</version>
+      <version>1.3.3</version>
     </dependency>
   </dependencies>
 </plugin>
@@ -631,7 +631,7 @@ Follow the [instructions](http://gradle-pitest-plugin.solidsoft.info/) to set up
 Add Descartes as a dependency of the `pitest` task
 
 ```
-pitest 'eu.stamp-project:descartes:1.3.2'
+pitest 'eu.stamp-project:descartes:1.3.3'
 ```
 
 then specify `descartes` in the `mutationEngine` option inside the plugin configuration.
@@ -640,7 +640,7 @@ An example of the final configuration could be:
 ```
 plugins {
     id 'java'
-    id 'info.solidsoft.pitest' version '1.5.1'
+    id 'info.solidsoft.pitest' version '1.15.0'
 }
 
 // Other configurations
@@ -652,12 +652,12 @@ repositories {
 
 dependencies {
     testImplementation group: 'junit', name: 'junit', version: '4.13.1'
-    pitest 'eu.stamp-project:descartes:1.3.2'
+    pitest 'eu.stamp-project:descartes:1.3.3'
 }
 
 pitest {
   mutationEngine = "descartes"
-  pitestVersion = "1.7.0"
+  pitestVersion = "1.20.2"
 }
 ```
 The `pitestVersion` property has to be specified to avoid version issues with the default version shipped with the Gradle plugin.

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -10,7 +10,7 @@ This file contains configuration snippets for Maven and Gradle using different c
 <plugin>
   <groupId>org.pitest</groupId>
   <artifactId>pitest-maven</artifactId>
-  <version>1.7.0</version>
+  <version>1.20.2</version>
   <configuration>
     <mutationEngine>descartes</mutationEngine>
   </configuration>
@@ -18,7 +18,7 @@ This file contains configuration snippets for Maven and Gradle using different c
     <dependency>
       <groupId>eu.stamp-project</groupId>
       <artifactId>descartes</artifactId>
-      <version>1.3.2</version>
+      <version>1.3.3</version>
     </dependency>
   </dependencies>
 </plugin>
@@ -30,7 +30,7 @@ This file contains configuration snippets for Maven and Gradle using different c
 <plugin>
   <groupId>org.pitest</groupId>
   <artifactId>pitest-maven</artifactId>
-  <version>1.7.0</version>
+  <version>1.20.2</version>
   <configuration>
     <mutationEngine>descartes</mutationEngine>
   </configuration>
@@ -38,12 +38,12 @@ This file contains configuration snippets for Maven and Gradle using different c
     <dependency>
       <groupId>eu.stamp-project</groupId>
       <artifactId>descartes</artifactId>
-      <version>1.3.2</version>
+      <version>1.3.3</version>
     </dependency>
     <dependency>
         <groupId>org.pitest</groupId>
         <artifactId>pitest-junit5-plugin</artifactId>
-        <version>0.12</version>
+        <version>1.2.3</version>
     </dependency>
   </dependencies>
 </plugin>
@@ -55,7 +55,7 @@ This file contains configuration snippets for Maven and Gradle using different c
 <plugin>
   <groupId>org.pitest</groupId>
   <artifactId>pitest-maven</artifactId>
-  <version>1.7.0</version>
+  <version>1.20.2</version>
   <configuration>
     <mutationEngine>descartes</mutationEngine>
     <mutators>
@@ -69,7 +69,7 @@ This file contains configuration snippets for Maven and Gradle using different c
     <dependency>
       <groupId>eu.stamp-project</groupId>
       <artifactId>descartes</artifactId>
-      <version>1.3.2</version>
+      <version>1.3.3</version>
     </dependency>
   </dependencies>
 </plugin>
@@ -81,7 +81,7 @@ This file contains configuration snippets for Maven and Gradle using different c
 <plugin>
   <groupId>org.pitest</groupId>
   <artifactId>pitest-maven</artifactId>
-  <version>1.7.0</version>
+  <version>1.20.2</version>
   <configuration>
     <outputFormats>
       <value>JSON</value>
@@ -94,7 +94,7 @@ This file contains configuration snippets for Maven and Gradle using different c
     <dependency>
       <groupId>eu.stamp-project</groupId>
       <artifactId>descartes</artifactId>
-      <version>1.3.2</version>
+      <version>1.3.3</version>
     </dependency>
   </dependencies>
 </plugin>
@@ -106,7 +106,7 @@ This file contains configuration snippets for Maven and Gradle using different c
 <plugin>
   <groupId>org.pitest</groupId>
   <artifactId>pitest-maven</artifactId>
-  <version>1.7.0</version>
+  <version>1.20.2</version>
   <configuration>
     <features>
         <feature>
@@ -119,7 +119,7 @@ This file contains configuration snippets for Maven and Gradle using different c
     <dependency>
       <groupId>eu.stamp-project</groupId>
       <artifactId>descartes</artifactId>
-      <version>1.3.2</version>
+      <version>1.3.3</version>
     </dependency>
   </dependencies>
 </plugin>
@@ -131,7 +131,7 @@ This file contains configuration snippets for Maven and Gradle using different c
 <plugin>
   <groupId>org.pitest</groupId>
   <artifactId>pitest-maven</artifactId>
-  <version>1.7.0</version>
+  <version>1.20.2</version>
   <configuration>
     <features>
         <feature>
@@ -144,7 +144,7 @@ This file contains configuration snippets for Maven and Gradle using different c
     <dependency>
       <groupId>eu.stamp-project</groupId>
       <artifactId>descartes</artifactId>
-      <version>1.3.2</version>
+      <version>1.3.3</version>
     </dependency>
   </dependencies>
 </plugin>
@@ -157,7 +157,7 @@ This file contains configuration snippets for Maven and Gradle using different c
 ```
 plugins {
     id 'java'
-    id 'info.solidsoft.pitest' version '1.5.1'
+    id 'info.solidsoft.pitest' version '1.15.0'
 }
 
 repositories {
@@ -167,12 +167,12 @@ repositories {
 
 dependencies {
     testImplementation group: 'junit', name: 'junit', version: '4.13.1'
-    pitest ''eu.stamp-project:descartes:1.3.2'
+    pitest 'eu.stamp-project:descartes:1.3.3'
 }
 
 pitest {
   mutationEngine = "descartes"
-  pitestVersion = "1.7.0"
+  pitestVersion = "1.20.2"
 }
 ```
 
@@ -180,7 +180,7 @@ pitest {
 ```
 plugins {
     id 'java'
-    id 'info.solidsoft.pitest' version '1.5.1'
+    id 'info.solidsoft.pitest' version '1.15.0'
 }
 
 repositories {
@@ -189,14 +189,13 @@ repositories {
 }
 
 dependencies {
-    testImplementation group: 'junit', name: 'junit', version: '4.13.1'
-    pitest 'eu.stamp-project:descartes:1.3.2'
+    pitest 'org.pitest:pitest-junit5-plugin:1.2.3'
+    pitest 'eu.stamp-project:descartes:1.3.3'
 }
 
 pitest {
   mutationEngine = "descartes"
-  pitestVersion = "1.7.0"
-  junit5PluginVersion = '0.12'
+  pitestVersion = "1.20.2"
 }
 ```
 
@@ -205,7 +204,7 @@ pitest {
 ```
 plugins {
     id 'java'
-    id 'info.solidsoft.pitest' version '1.5.1'
+    id 'info.solidsoft.pitest' version '1.15.0'
 }
 
 repositories {
@@ -215,12 +214,12 @@ repositories {
 
 dependencies {
     testImplementation group: 'junit', name: 'junit', version: '4.13.1'
-    pitest 'eu.stamp-project:descartes:1.3.2'
+    pitest 'eu.stamp-project:descartes:1.3.3'
 }
 
 pitest {
   mutationEngine = "descartes"
-  pitestVersion = "1.7.0"
+  pitestVersion = "1.20.2"
   mutators = [ '1.2', 'true', 'optional', '"a"' ]
 }
 ```
@@ -230,7 +229,7 @@ pitest {
 ```
 plugins {
     id 'java'
-    id 'info.solidsoft.pitest' version '1.5.1'
+    id 'info.solidsoft.pitest' version '1.15.0'
 }
 
 repositories {
@@ -240,12 +239,12 @@ repositories {
 
 dependencies {
     testImplementation group: 'junit', name: 'junit', version: '4.13.1'
-    pitest 'eu.stamp-project:descartes:1.3.2'
+    pitest 'eu.stamp-project:descartes:1.3.3'
 }
 
 pitest {
   mutationEngine = "descartes"
-  pitestVersion = "1.7.0"
+  pitestVersion = "1.20.2"
   features = ['+STOP_METHODS()']
 }
 ```
@@ -255,7 +254,7 @@ pitest {
 ```
 plugins {
     id 'java'
-    id 'info.solidsoft.pitest' version '1.5.1'
+    id 'info.solidsoft.pitest' version '1.15.0'
 }
 
 repositories {
@@ -265,12 +264,12 @@ repositories {
 
 dependencies {
     testImplementation group: 'junit', name: 'junit', version: '4.13.1'
-    pitest 'eu.stamp-project:descartes:1.3.2'
+    pitest 'eu.stamp-project:descartes:1.3.3'
 }
 
 pitest {
   mutationEngine = "descartes"
-  pitestVersion = "1.7.0"
+  pitestVersion = "1.20.2"
   features = ['-DO_NOT_MUTATE()']
 }
 ```


### PR DESCRIPTION
Since we already have version 1.3.3, I have taken the liberty of updating Pitest and Descartes versions in README.md and how-to.md examples

I also added links to two sample repositories that demonstrate effective mutation testing in Spring Boot 3 — one using Maven and the other using Gradle.

@oscarlvp if you see that they are not suitable, tell me and revert the commit